### PR TITLE
fix header relay

### DIFF
--- a/packages/onchain/contracts/ReservePoolController.sol
+++ b/packages/onchain/contracts/ReservePoolController.sol
@@ -461,11 +461,8 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
     uint256 uVbtcBalance
   ) internal pure returns (bool) {
     uint256 uPrice = uWethBalance.mul(BONE).div(uVbtcBalance);
-    uint256 bPrice = bWethWeight.mul(BONE).mul(bWethBalance).div(bVbtcWeight.mul(bVbtcBalance));
-    require(
-      uPrice.div(POOL_PRICE_DIV) == bPrice.div(POOL_PRICE_DIV),
-      "price imbalance between pools"
-    );
+    uint256 bPrice = bVbtcWeight.mul(BONE).mul(bWethBalance).div(bWethWeight.mul(bVbtcBalance));
+    require(uPrice.div(BONE) == bPrice.div(BONE), "price imbalance between pools");
   }
 
   /**
@@ -599,9 +596,11 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
     // adjusts weight in reserve pool
     {
       // read uni weights
-      // a = uni wEth reserve
-      // b = uni vBtc Reserve
-      (uint256 reserveWeth, uint256 reserveVbtc) = getReserves(uniRouter.factory(), address(wEth), address(vBtc));
+      (uint256 reserveWeth, uint256 reserveVbtc) = getReserves(
+        uniRouter.factory(),
+        address(wEth),
+        address(vBtc)
+      );
       uint256 vBtcBalance = bPool.getBalance(address(vBtc));
       uint256 wEthBalance = bPool.getBalance(address(wEth));
 

--- a/packages/onchain/contracts/ReservePoolController.sol
+++ b/packages/onchain/contracts/ReservePoolController.sol
@@ -496,7 +496,6 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
       require(
         reserveWeth.mul(BONE).div(reserveVbtc).div(POOL_PRICE_DIV) ==
           IBtcPriceOracle(spotOracle).consult(BONE).div(POOL_PRICE_DIV),
-
         // use this for upgrade to get around governance delay
         //reserveWeth.mul(BONE).div(reserveVbtc).div(POOL_PRICE_DIV) ==
         //  IBtcPriceOracle(0x91AE9424B706616A531831Fb4A8988726B398837).consult(BONE).div(POOL_PRICE_DIV),

--- a/packages/onchain/contracts/ReservePoolController.sol
+++ b/packages/onchain/contracts/ReservePoolController.sol
@@ -599,7 +599,9 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
     // adjusts weight in reserve pool
     {
       // read uni weights
-      (uint256 a, uint256 b) = getReserves(uniRouter.factory(), address(wEth), address(vBtc));
+      // a = uni wEth reserve
+      // b = uni vBtc Reserve
+      (uint256 reserveWeth, uint256 reserveVbtc) = getReserves(uniRouter.factory(), address(wEth), address(vBtc));
       uint256 vBtcBalance = bPool.getBalance(address(vBtc));
       uint256 wEthBalance = bPool.getBalance(address(wEth));
 

--- a/packages/onchain/contracts/ReservePoolController.sol
+++ b/packages/onchain/contracts/ReservePoolController.sol
@@ -258,7 +258,15 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
   {
     uint256 swapFee = bPool.getSwapFee();
     bool isPublicSwap = bPool.isPublicSwap();
-    return (address(uniRouter), oracle, maxVbtcWeight, blockTimestampLast, swapFee, isPublicSwap, spotOracle);
+    return (
+      address(uniRouter),
+      oracle,
+      maxVbtcWeight,
+      blockTimestampLast,
+      swapFee,
+      isPublicSwap,
+      spotOracle
+    );
   }
 
   function deployPool(uint256 initialSwapFee) external {
@@ -454,7 +462,10 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
   ) internal pure returns (bool) {
     uint256 uPrice = uWethBalance.mul(BONE).div(uVbtcBalance);
     uint256 bPrice = bWethWeight.mul(BONE).mul(bWethBalance).div(bVbtcWeight.mul(bVbtcBalance));
-    require(uPrice.div(POOL_PRICE_DIV) == bPrice.div(POOL_PRICE_DIV), "price imbalance between pools");
+    require(
+      uPrice.div(POOL_PRICE_DIV) == bPrice.div(POOL_PRICE_DIV),
+      "price imbalance between pools"
+    );
   }
 
   /**
@@ -488,6 +499,7 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
       require(
         reserveWeth.mul(BONE).div(reserveVbtc).div(POOL_PRICE_DIV) ==
           IBtcPriceOracle(spotOracle).consult(BONE).div(POOL_PRICE_DIV),
+
         // use this for upgrade to get around governance delay
         //reserveWeth.mul(BONE).div(reserveVbtc).div(POOL_PRICE_DIV) ==
         //  IBtcPriceOracle(0x91AE9424B706616A531831Fb4A8988726B398837).consult(BONE).div(POOL_PRICE_DIV),
@@ -587,11 +599,7 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
     // adjusts weight in reserve pool
     {
       // read uni weights
-      (uint256 a, uint256 b) = getReserves(
-        uniRouter.factory(),
-        address(wEth),
-        address(vBtc)
-      );
+      (uint256 a, uint256 b) = getReserves(uniRouter.factory(), address(wEth), address(vBtc));
       uint256 vBtcBalance = bPool.getBalance(address(vBtc));
       uint256 wEthBalance = bPool.getBalance(address(wEth));
 

--- a/packages/onchain/contracts/ReservePoolController.sol
+++ b/packages/onchain/contracts/ReservePoolController.sol
@@ -258,15 +258,7 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
   {
     uint256 swapFee = bPool.getSwapFee();
     bool isPublicSwap = bPool.isPublicSwap();
-    return (
-      address(uniRouter),
-      oracle,
-      maxVbtcWeight,
-      blockTimestampLast,
-      swapFee,
-      isPublicSwap,
-      spotOracle
-    );
+    return (address(uniRouter), oracle, maxVbtcWeight, blockTimestampLast, swapFee, isPublicSwap, spotOracle);
   }
 
   function deployPool(uint256 initialSwapFee) external {
@@ -459,17 +451,10 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
     uint256 bVbtcWeight,
     uint256 uWethBalance,
     uint256 uVbtcBalance
-  )
-    internal
-    returns (
-      // ) internal pure returns (bool) {
-      bool
-    )
-  {
+  ) internal pure returns (bool) {
     uint256 uPrice = uWethBalance.mul(BONE).div(uVbtcBalance);
-    uint256 bPrice = bVbtcWeight.mul(BONE).mul(bWethBalance).div(bWethWeight.mul(bVbtcBalance));
-    //emit Data(uPrice.div(POOL_PRICE_DIV), bPrice.div(POOL_PRICE_DIV));
-    require(uPrice.div(BONE) == bPrice.div(BONE), "price imbalance between pools");
+    uint256 bPrice = bWethWeight.mul(BONE).mul(bWethBalance).div(bVbtcWeight.mul(bVbtcBalance));
+    require(uPrice.div(POOL_PRICE_DIV) == bPrice.div(POOL_PRICE_DIV), "price imbalance between pools");
   }
 
   /**
@@ -602,7 +587,7 @@ contract ReservePoolController is ERC20UpgradeSafe, BMath, IBorrower, OwnableUpg
     // adjusts weight in reserve pool
     {
       // read uni weights
-      (uint256 reserveWeth, uint256 reserveVbtc) = getReserves(
+      (uint256 a, uint256 b) = getReserves(
         uniRouter.factory(),
         address(wEth),
         address(vBtc)

--- a/packages/onchain/contracts/SpotPriceOracle.sol
+++ b/packages/onchain/contracts/SpotPriceOracle.sol
@@ -68,9 +68,7 @@ contract SpotPriceOracle is IBtcPriceOracle {
 
     // overflow is desired, casting never truncates
     // cumulative price is in (uq112x112 price * seconds) units so we simply wrap it after division by time elapsed
-    priceAverage = FixedPoint.uq112x112(
-      uint224((priceCumulative - priceCumulativeLast) / timeElapsed)
-    );
+    priceAverage = FixedPoint.uq112x112(uint224((priceCumulative - priceCumulativeLast) / timeElapsed));
     priceCumulativeLast = priceCumulative;
     blockTimestampLast = blockTimestamp;
   }

--- a/packages/onchain/contracts/SpotPriceOracle.sol
+++ b/packages/onchain/contracts/SpotPriceOracle.sol
@@ -68,7 +68,9 @@ contract SpotPriceOracle is IBtcPriceOracle {
 
     // overflow is desired, casting never truncates
     // cumulative price is in (uq112x112 price * seconds) units so we simply wrap it after division by time elapsed
-    priceAverage = FixedPoint.uq112x112(uint224((priceCumulative - priceCumulativeLast) / timeElapsed));
+    priceAverage = FixedPoint.uq112x112(
+      uint224((priceCumulative - priceCumulativeLast) / timeElapsed)
+    );
     priceCumulativeLast = priceCumulative;
     blockTimestampLast = blockTimestamp;
   }

--- a/packages/onchain/contracts/VbtcToken.sol
+++ b/packages/onchain/contracts/VbtcToken.sol
@@ -238,7 +238,7 @@ contract VbtcToken is FlashERC20, ERC20CappedUpgradeSafe {
 
   function _checkNew(bytes29 _headers) internal view returns (bool) {
     bytes29 _target = _headers.indexHeaderArray(0);
-    try relay.findHeight(_target.hash256()) {
+    try relay.findHeight(_target.hash256())  {
       revert("already included");
     } catch Error(string memory) {
       return true;
@@ -277,6 +277,7 @@ contract VbtcToken is FlashERC20, ERC20CappedUpgradeSafe {
       "mark new heaviest failed"
     );
     strudel.mint(msg.sender, relayReward / 2);
+    return true;
   }
 
   /// @dev             Burns an amount of the token from the given account's balance.

--- a/packages/onchain/contracts/VbtcToken.sol
+++ b/packages/onchain/contracts/VbtcToken.sol
@@ -238,7 +238,11 @@ contract VbtcToken is FlashERC20, ERC20CappedUpgradeSafe {
 
   function _checkNew(bytes29 _headers) internal returns (bool) {
     bytes29 _target = _headers.indexHeaderArray(0);
-    require(relay.findHeight(_target.hash256()) == 0, "already included");
+    try relay.findHeight(_target.hash256()) {
+      revert("already included");
+    } catch Error(string memory) {
+      return true;
+    }
   }
 
   function addHeaders(bytes calldata _anchor, bytes calldata _headers) external returns (bool) {
@@ -270,7 +274,7 @@ contract VbtcToken is FlashERC20, ERC20CappedUpgradeSafe {
       relay.markNewHeaviest(_ancestor, _currentBest, _newBest, _limit),
       "mark new heaviest failed"
     );
-    strudel.mint(msg.sender, relayReward);
+    strudel.mint(msg.sender, relayReward / 2);
   }
 
   /// @dev             Burns an amount of the token from the given account's balance.

--- a/packages/onchain/contracts/VbtcToken.sol
+++ b/packages/onchain/contracts/VbtcToken.sol
@@ -236,7 +236,13 @@ contract VbtcToken is FlashERC20, ERC20CappedUpgradeSafe {
     require(false, "not implemented");
   }
 
+  function _checkNew(bytes29 _headers) internal returns (bool) {
+    bytes29 _target = _headers.indexHeaderArray(0);
+    require(relay.findHeight(_target.hash256()) == 0, "already included");
+  }
+
   function addHeaders(bytes calldata _anchor, bytes calldata _headers) external returns (bool) {
+    _checkNew(_headers.ref(0).tryAsHeaderArray());
     require(relay.addHeaders(_anchor, _headers), "add header failed");
     strudel.mint(msg.sender, relayReward.mul(_headers.length / 80));
   }
@@ -246,6 +252,7 @@ contract VbtcToken is FlashERC20, ERC20CappedUpgradeSafe {
     bytes calldata _oldPeriodEndHeader,
     bytes calldata _headers
   ) external returns (bool) {
+    _checkNew(_headers.ref(0).tryAsHeaderArray());
     require(
       relay.addHeadersWithRetarget(_oldPeriodStartHeader, _oldPeriodEndHeader, _headers),
       "add header with retarget failed"

--- a/packages/onchain/contracts/VbtcToken.sol
+++ b/packages/onchain/contracts/VbtcToken.sol
@@ -236,7 +236,7 @@ contract VbtcToken is FlashERC20, ERC20CappedUpgradeSafe {
     require(false, "not implemented");
   }
 
-  function _checkNew(bytes29 _headers) internal returns (bool) {
+  function _checkNew(bytes29 _headers) internal view returns (bool) {
     bytes29 _target = _headers.indexHeaderArray(0);
     try relay.findHeight(_target.hash256()) {
       revert("already included");
@@ -249,6 +249,7 @@ contract VbtcToken is FlashERC20, ERC20CappedUpgradeSafe {
     _checkNew(_headers.ref(0).tryAsHeaderArray());
     require(relay.addHeaders(_anchor, _headers), "add header failed");
     strudel.mint(msg.sender, relayReward.mul(_headers.length / 80));
+    return true;
   }
 
   function addHeadersWithRetarget(
@@ -262,6 +263,7 @@ contract VbtcToken is FlashERC20, ERC20CappedUpgradeSafe {
       "add header with retarget failed"
     );
     strudel.mint(msg.sender, relayReward.mul(_headers.length / 80));
+    return true;
   }
 
   function markNewHeaviest(

--- a/packages/onchain/contracts/mocks/MockRelay.sol
+++ b/packages/onchain/contracts/mocks/MockRelay.sol
@@ -71,7 +71,11 @@ contract MockRelay is IRelay {
   /// @param _digest  The header digest to search for
   /// @return         The height of the header, or error if unknown
   function findHeight(bytes32 _digest) external override view returns (uint256) {
-    return heights[_digest];
+    uint256 height = heights[_digest];
+    if (height == 0) {
+      revert("Not included!");
+    }
+    return height;
   }
 
   /// @notice             Checks if a digest is an ancestor of the current one

--- a/packages/onchain/test/reservePoolController.test.ts
+++ b/packages/onchain/test/reservePoolController.test.ts
@@ -120,7 +120,11 @@ describe('ReservePoolController', async () => {
     ]);
 
     // deploy spot oracle
-    spotOracle = await new SpotPriceOracleFactory(signers[0]).deploy(factoryV2.address, wEth.address, vBtc.address);
+    spotOracle = await new SpotPriceOracleFactory(signers[0]).deploy(
+      factoryV2.address,
+      wEth.address,
+      vBtc.address
+    );
 
     // address _bPoolFactory,
     bFactory = await new MockBFactoryFactory(signers[0]).deploy();
@@ -162,8 +166,8 @@ describe('ReservePoolController', async () => {
       oracle.address,
       expandTo18Decimals(15),
       initialTradeFee,
-      true //,
-      //spotOracle.address
+      true,
+      spotOracle.address
     );
 
     // try initialize again

--- a/packages/onchain/test/reservePoolController.test.ts
+++ b/packages/onchain/test/reservePoolController.test.ts
@@ -166,8 +166,7 @@ describe('ReservePoolController', async () => {
       oracle.address,
       expandTo18Decimals(15),
       initialTradeFee,
-      true,
-      spotOracle.address
+      true
     );
 
     // try initialize again

--- a/packages/onchain/test/reservePoolController.test.ts
+++ b/packages/onchain/test/reservePoolController.test.ts
@@ -172,10 +172,8 @@ describe('ReservePoolController', async () => {
 
     // try initialize again
     await expect(controller.deployPool(initialTradeFee)).to.be.reverted;
-    console.log('here2');
     // try some trade
     await expect(controller.resyncWeights()).to.be.reverted;
-    console.log('here3');
     // set pool for later
     bPool = new BPoolFactory(signers[0]).attach(await controller.bPool());
   });

--- a/packages/onchain/test/reservePoolController.test.ts
+++ b/packages/onchain/test/reservePoolController.test.ts
@@ -120,11 +120,7 @@ describe('ReservePoolController', async () => {
     ]);
 
     // deploy spot oracle
-    spotOracle = await new SpotPriceOracleFactory(signers[0]).deploy(
-      factoryV2.address,
-      wEth.address,
-      vBtc.address
-    );
+    spotOracle = await new SpotPriceOracleFactory(signers[0]).deploy(factoryV2.address, wEth.address, vBtc.address);
 
     // address _bPoolFactory,
     bFactory = await new MockBFactoryFactory(signers[0]).deploy();
@@ -172,8 +168,10 @@ describe('ReservePoolController', async () => {
 
     // try initialize again
     await expect(controller.deployPool(initialTradeFee)).to.be.reverted;
+    console.log('here2');
     // try some trade
     await expect(controller.resyncWeights()).to.be.reverted;
+    console.log('here3');
     // set pool for later
     bPool = new BPoolFactory(signers[0]).attach(await controller.bPool());
   });

--- a/packages/onchain/test/vbtcToken.test.ts
+++ b/packages/onchain/test/vbtcToken.test.ts
@@ -1,27 +1,27 @@
-import {ethers, upgrades} from '@nomiclabs/buidler';
-import {Signer, Contract} from 'ethers';
-import {getAdminAddress} from '@openzeppelin/upgrades-core';
+import { ethers, upgrades } from '@nomiclabs/buidler';
+import { Signer, Contract } from 'ethers';
+import { getAdminAddress } from '@openzeppelin/upgrades-core';
 import chai from 'chai';
-import {solidity} from 'ethereum-waffle';
+import { solidity } from 'ethereum-waffle';
 import vector from './testVector.json';
 import REGULAR_CHAIN from './headers.json';
-import {expandTo18Decimals, concatenateHexStrings} from './shared/utilities';
+import { expandTo18Decimals, concatenateHexStrings } from './shared/utilities';
 import ProxyAdminArtifact from '@openzeppelin/upgrades-core/artifacts/ProxyAdmin.json';
 import AdminUpgradeabilityProxyArtifact from '@openzeppelin/upgrades-core/artifacts/AdminUpgradeabilityProxy.json';
-import {VbtcToken} from '../typechain/VbtcToken';
-import {StrudelToken} from '../typechain/StrudelToken';
-import {StrudelTokenFactory} from '../typechain/StrudelTokenFactory';
-import {MockRelay} from '../typechain/MockRelay';
-import {MockRelayFactory} from '../typechain/MockRelayFactory';
-import {MockBorrower} from '../typechain/MockBorrower';
-import {MockBorrowerFactory} from '../typechain/MockBorrowerFactory';
-import {MockVbtcUpgraded} from '../typechain/MockVbtcUpgraded';
-import {MockVbtcUpgradedFactory} from '../typechain/MockVbtcUpgradedFactory';
-import {Timelock} from '../typechain/Timelock';
-import {TimelockFactory} from '../typechain/TimelockFactory';
+import { VbtcToken } from '../typechain/VbtcToken';
+import { StrudelToken } from '../typechain/StrudelToken';
+import { StrudelTokenFactory } from '../typechain/StrudelTokenFactory';
+import { MockRelay } from '../typechain/MockRelay';
+import { MockRelayFactory } from '../typechain/MockRelayFactory';
+import { MockBorrower } from '../typechain/MockBorrower';
+import { MockBorrowerFactory } from '../typechain/MockBorrowerFactory';
+import { MockVbtcUpgraded } from '../typechain/MockVbtcUpgraded';
+import { MockVbtcUpgradedFactory } from '../typechain/MockVbtcUpgradedFactory';
+import { Timelock } from '../typechain/Timelock';
+import { TimelockFactory } from '../typechain/TimelockFactory';
 
 chai.use(solidity);
-const {expect} = chai;
+const { expect } = chai;
 
 const BYTES32_0 = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
@@ -93,7 +93,7 @@ describe('VBTC', async () => {
           test.VIN,
           test.VOUT
         )
-      ).to.be.revertedWith('height not found in relay');
+      ).to.be.revertedWith('Not included!');
 
       await relay.addHeader(test.BLOCK_HASH, 200);
       await expect(
@@ -184,7 +184,7 @@ describe('VBTC', async () => {
     const bobAddr = await bob.getAddress();
 
     // prepare data
-    const {chain, genesis} = REGULAR_CHAIN;
+    const { chain, genesis } = REGULAR_CHAIN;
     const headerHex = chain.map((header) => header.hex);
     let headers = concatenateHexStrings(headerHex.slice(0, 3));
 

--- a/packages/onchain/test/vbtcToken.test.ts
+++ b/packages/onchain/test/vbtcToken.test.ts
@@ -1,27 +1,27 @@
-import { ethers, upgrades } from '@nomiclabs/buidler';
-import { Signer, Contract } from 'ethers';
-import { getAdminAddress } from '@openzeppelin/upgrades-core';
+import {ethers, upgrades} from '@nomiclabs/buidler';
+import {Signer, Contract} from 'ethers';
+import {getAdminAddress} from '@openzeppelin/upgrades-core';
 import chai from 'chai';
-import { solidity } from 'ethereum-waffle';
+import {solidity} from 'ethereum-waffle';
 import vector from './testVector.json';
 import REGULAR_CHAIN from './headers.json';
-import { expandTo18Decimals, concatenateHexStrings } from './shared/utilities';
+import {expandTo18Decimals, concatenateHexStrings} from './shared/utilities';
 import ProxyAdminArtifact from '@openzeppelin/upgrades-core/artifacts/ProxyAdmin.json';
 import AdminUpgradeabilityProxyArtifact from '@openzeppelin/upgrades-core/artifacts/AdminUpgradeabilityProxy.json';
-import { VbtcToken } from '../typechain/VbtcToken';
-import { StrudelToken } from '../typechain/StrudelToken';
-import { StrudelTokenFactory } from '../typechain/StrudelTokenFactory';
-import { MockRelay } from '../typechain/MockRelay';
-import { MockRelayFactory } from '../typechain/MockRelayFactory';
-import { MockBorrower } from '../typechain/MockBorrower';
-import { MockBorrowerFactory } from '../typechain/MockBorrowerFactory';
-import { MockVbtcUpgraded } from '../typechain/MockVbtcUpgraded';
-import { MockVbtcUpgradedFactory } from '../typechain/MockVbtcUpgradedFactory';
-import { Timelock } from '../typechain/Timelock';
-import { TimelockFactory } from '../typechain/TimelockFactory';
+import {VbtcToken} from '../typechain/VbtcToken';
+import {StrudelToken} from '../typechain/StrudelToken';
+import {StrudelTokenFactory} from '../typechain/StrudelTokenFactory';
+import {MockRelay} from '../typechain/MockRelay';
+import {MockRelayFactory} from '../typechain/MockRelayFactory';
+import {MockBorrower} from '../typechain/MockBorrower';
+import {MockBorrowerFactory} from '../typechain/MockBorrowerFactory';
+import {MockVbtcUpgraded} from '../typechain/MockVbtcUpgraded';
+import {MockVbtcUpgradedFactory} from '../typechain/MockVbtcUpgradedFactory';
+import {Timelock} from '../typechain/Timelock';
+import {TimelockFactory} from '../typechain/TimelockFactory';
 
 chai.use(solidity);
-const { expect } = chai;
+const {expect} = chai;
 
 const BYTES32_0 = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
@@ -184,7 +184,7 @@ describe('VBTC', async () => {
     const bobAddr = await bob.getAddress();
 
     // prepare data
-    const { chain, genesis } = REGULAR_CHAIN;
+    const {chain, genesis} = REGULAR_CHAIN;
     const headerHex = chain.map((header) => header.hex);
     let headers = concatenateHexStrings(headerHex.slice(0, 3));
 

--- a/packages/onchain/test/vbtcToken.test.ts
+++ b/packages/onchain/test/vbtcToken.test.ts
@@ -213,6 +213,11 @@ describe('VBTC', async () => {
     await vBtc.connect(bob).addHeaders(chain[2].hex, headers);
     const bobBal2 = await strudel.balanceOf(bobAddr);
     expect(bobBal2).to.eq(bobBal1.add(expandTo18Decimals(30).mul(3)));
+
+    // don't allow to relay twice
+    await expect(vBtc.connect(bob).addHeaders(chain[2].hex, headers)).to.be.revertedWith(
+      "already included"
+    );
   });
 
   describe('upgradeabliity', async () => {

--- a/packages/onchain/test/vbtcToken.test.ts
+++ b/packages/onchain/test/vbtcToken.test.ts
@@ -216,7 +216,7 @@ describe('VBTC', async () => {
 
     // don't allow to relay twice
     await expect(vBtc.connect(bob).addHeaders(chain[2].hex, headers)).to.be.revertedWith(
-      "already included"
+      'already included'
     );
   });
 


### PR DESCRIPTION
- there was a possibility to submit same header twice, potentially inflating $TRDL infinitely. this plugs the whole.
- on mainnet we found that relayer throws an exception (other than in tests), so the relay functions got accidentally disabled.