### PR TITLE
cache infura provider to hopefully avoid net_version requests on every start

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -175,3 +175,10 @@ curl  --data '{"txData": "02000000017aa6eca8ed999fd0205a3a8af9d60e2b1893cb1245ab
 ```
 
 [this code](https://github.com/summa-tx/bitcoin-spv/tree/master/js) can be used to verify proofs client side.
+
+
+## deploy
+
+```
+BCD_USERNAME=xxx BCD_PASSWORD=yyy PROVIDER_URL=https://mainnet.infura.io/v3/zzz yarn deploy
+```

--- a/packages/backend/serverless.yml
+++ b/packages/backend/serverless.yml
@@ -6,7 +6,7 @@ custom:
   table: strudel-${opt:stage}
   region: eu-west-1
   bcdRpc: 'bcd.strudel.finance'
-  bcdPost: 8332
+  bcdPort: 8332
 
 
 package:
@@ -77,7 +77,7 @@ functions:
     environment:
       PROVIDER_URL: ${env:PROVIDER_URL}
       BCD_RPC: ${env:BCD_RPC, self:custom.bcdRpc}
-      BCD_PORT: ${env:BCD_PORT, self:custom.bcdPost}
+      BCD_PORT: ${env:BCD_PORT, self:custom.bcdPort}
       BCD_USERNAME: ${env:BCD_USERNAME}
       BCD_PASSWORD: ${env:BCD_PASSWORD}
       TABLE_NAME:

--- a/packages/backend/src/strudel.js
+++ b/packages/backend/src/strudel.js
@@ -6,13 +6,17 @@ const StrudelHandler = require('./strudelHandler');
 const request = require('request');
 const { PoorManRpc } = require('./utils/poorManRpc');
 
+let provider;
+
 exports.handler = async (event, context) => {
   const providerUrl = process.env.PROVIDER_URL;
   const body = typeof event.body === 'string' ? JSON.parse(event.body) : event.body;
   const path = event.requestPath;
   const method = event.method;
 
-  const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+  if (!provider) {
+    provider = new ethers.providers.JsonRpcProvider(providerUrl);
+  }
   const bclient = new PoorManRpc(
     request,
     process.env.BCD_USERNAME,


### PR DESCRIPTION
a bunch of function invocations
<img width="1268" alt="Screen Shot 2020-10-14 at 10 04 13 AM" src="https://user-images.githubusercontent.com/659301/95962601-dde07700-0e06-11eb-8635-8f56e8740caa.png">

cause a lot of net_verison requests
<img width="977" alt="Screen Shot 2020-10-14 at 10 07 03 AM" src="https://user-images.githubusercontent.com/659301/95962633-e8027580-0e06-11eb-9105-827b60e57993.png">

while the provider was actually used only used 22 times. try to avoid by caching it in global scope.